### PR TITLE
Add Common Good Bergamot

### DIFF
--- a/src/components/Detergent/data/profiles/common-good-bergamot.ts
+++ b/src/components/Detergent/data/profiles/common-good-bergamot.ts
@@ -1,0 +1,32 @@
+import { Ingredient } from '../../../common/types/Ingredient';
+import { DetergentProfile } from '../../types/DetergentProfile';
+import { DetergentType } from '../../types/DetergentType';
+
+const ingredients: Ingredient[] = [
+  Ingredient.Water,
+  Ingredient.EthoxylatedAlcohol,
+  Ingredient.SodiumDodecylbenzenesulfonate,
+  Ingredient.SodiumCocoate,
+  Ingredient.SodiumCitrate,
+  Ingredient.LauramineOxide,
+  Ingredient.Propanediol,
+  Ingredient.EssentialOil, // listed as "essential oil (when used)" — conditional, present in scented variants
+  Ingredient.Phenoxyethanol,
+  Ingredient.EthylhexylGlycerin,
+  Ingredient.Protease,
+  Ingredient.Lipase,
+  Ingredient.Mannanase,
+  Ingredient.Amylase,
+  Ingredient.PectateLyase,
+  Ingredient.SodiumBicarbonate,
+];
+
+const CommonGoodBergamot: DetergentProfile = new DetergentProfile(
+  'Bergamot',
+  'Common Good',
+  DetergentType.Liquid,
+  ingredients,
+  new Date('2026-03-15'),
+);
+
+export default CommonGoodBergamot;

--- a/src/components/Detergent/data/profiles/index.ts
+++ b/src/components/Detergent/data/profiles/index.ts
@@ -21,6 +21,7 @@ export { default as ArmAndHammerPowerSheetsFreshBreeze } from './arm-and-hammer-
 export { default as ArmAndHammerSensitiveSkinPlusFreshScent } from './arm-and-hammer-sensitive-skin-plus-fresh-scent';
 export { default as ArielOriginal } from './ariel-original';
 export { default as ArielTouchOfDownyPowder } from './ariel-touch-of-downy-powder';
+export { default as CommonGoodBergamot } from './common-good-bergamot';
 export { default as CountrySavePowderLaundryDetergent } from './country-save-powder-laundry-detergent';
 export { default as DreftStage1Newborn } from './dreft-stage-1-newborn';
 export { default as GainOdorDefenseSuperFresh } from './gain-odor-defense-super-fresh';

--- a/src/components/common/types/AnionicSurfactants.ts
+++ b/src/components/common/types/AnionicSurfactants.ts
@@ -10,6 +10,7 @@ AnionicSurfactants.add(Ingredient.MEADedecylbenzenesulfonate);
 AnionicSurfactants.add(Ingredient.MEALAS);
 AnionicSurfactants.add(Ingredient.MEALaurethSulfate);
 AnionicSurfactants.add(Ingredient.SodiumC10_16Alkylbenzenesulfonate);
+AnionicSurfactants.add(Ingredient.SodiumDodecylbenzenesulfonate);
 AnionicSurfactants.add(Ingredient.SodiumLaurethSulfate);
 AnionicSurfactants.add(Ingredient.SodiumLaurylSulfate);
 AnionicSurfactants.add(Ingredient.SodiumMEAC10_16Alkylbenzenesulfonate);

--- a/src/components/common/types/Ingredient.ts
+++ b/src/components/common/types/Ingredient.ts
@@ -117,8 +117,25 @@ export enum Ingredient {
   DipropyleneGlycol = 'Dipropylene Glycol',
   DisodiumDistyrylbiphenylDisulfonate = 'Disodium Distyrylbiphenyl Disulfonate',
   DNase = 'DNase',
+  /**
+   * Essential Oil is a natural aromatic extract derived from plants, used in laundry detergents
+   * as a scent ingredient. May be listed as conditional on the label (e.g. "when used"),
+   * indicating it is present only in scented variants.
+   */
+  EssentialOil = 'Essential Oil',
   Ethanol = 'Ethanol',
   Ethanolamine = 'Ethanolamine',
+  /**
+   * Ethoxylated Alcohol is a generic nonionic surfactant term for a fatty alcohol reacted with
+   * ethylene oxide, used in laundry detergents to reduce surface tension and improve soil removal.
+   * Listed without a carbon chain specification; do not map to a specific C-range variant.
+   */
+  EthoxylatedAlcohol = 'Ethoxylated Alcohol',
+  /**
+   * Ethylhexylglycerin (1,2-octanediol/glycerin ether) is a synthetic humectant and skin-conditioning
+   * agent used in laundry detergents as a preservative booster and antimicrobial co-agent.
+   */
+  EthylhexylGlycerin = 'Ethylhexylglycerin',
   /**
    * Fatty Acids C8-18 and C18-Unsaturated Sodium Salts is the sodium salt form of a blend of
    * C8-C18 saturated fatty acids and C18 unsaturated fatty acids, used as a soap and surfactant
@@ -474,6 +491,12 @@ export enum Ingredient {
    */
   SodiumCocoate = 'Sodium Cocoate',
   SodiumCumenesulfonate = 'Sodium Cumenesulfonate',
+  /**
+   * Sodium Dodecylbenzenesulfonate is an anionic surfactant (the sodium salt of C12
+   * alkylbenzenesulfonic acid) used as a primary cleaning agent in laundry detergents.
+   * Note: distinct from Sodium C10-16 Alkylbenzenesulfonate, which covers a broader carbon range.
+   */
+  SodiumDodecylbenzenesulfonate = 'Sodium Dodecylbenzenesulfonate',
   SodiumFormate = 'Sodium Formate',
   /**
    * Sodium Gluconate is the sodium salt of gluconic acid, used in laundry detergents as a

--- a/src/components/common/types/NonionicSurfactants.ts
+++ b/src/components/common/types/NonionicSurfactants.ts
@@ -11,6 +11,7 @@ NonionicSurfactants.add(Ingredient.C12_13Pareth_2);
 NonionicSurfactants.add(Ingredient.C12_14AlcoholsEthoxylated);
 NonionicSurfactants.add(Ingredient.C12_15AlcoholsEthoxylated);
 NonionicSurfactants.add(Ingredient.DecylGlucoside);
+NonionicSurfactants.add(Ingredient.EthoxylatedAlcohol);
 NonionicSurfactants.add(Ingredient.Laureth_6);
 NonionicSurfactants.add(Ingredient.Laureth_7);
 NonionicSurfactants.add(Ingredient.Laureth_12);

--- a/src/components/common/types/Preservatives.ts
+++ b/src/components/common/types/Preservatives.ts
@@ -4,6 +4,7 @@ const Preservatives: Set<Ingredient> = new Set();
 
 Preservatives.add(Ingredient.Benzisothiazolinone);
 Preservatives.add(Ingredient.BHT);
+Preservatives.add(Ingredient.EthylhexylGlycerin);
 Preservatives.add(Ingredient.LoniceraJaponicaFlowerExtract);
 Preservatives.add(Ingredient.Methylchloroisothiazolinone);
 Preservatives.add(Ingredient.Methylisothiazolinone);

--- a/src/components/common/types/Scents.ts
+++ b/src/components/common/types/Scents.ts
@@ -2,6 +2,7 @@ import { Ingredient } from './Ingredient';
 
 const Scents: Set<Ingredient> = new Set();
 
+Scents.add(Ingredient.EssentialOil);
 Scents.add(Ingredient.Fragrance);
 Scents.add(Ingredient.LavandulaHybridaOil);
 


### PR DESCRIPTION
## Description

Closes #353

Add detergent product: **Common Good Bergamot**

## Unknowns / Ambiguities

- **Essential Oil** is listed as "essential oil (when used)" on the source — conditional ingredient, present only in scented variants. Included in the ingredients array with a comment.
- **Detergent type** not explicitly stated on source; inferred as Liquid from ingredient profile.

## Source(s)

- **Primary source:** Manual entry (packaging)
- **Date accessed:** 2026-03-15
- **Region:** not specified