### PR TITLE
Fix ingredient category assignments for Fillers

### DIFF
--- a/src/components/common/types/Fillers.ts
+++ b/src/components/common/types/Fillers.ts
@@ -13,7 +13,6 @@ const Fillers: Set<Ingredient> = new Set();
 
 Fillers.add(Ingredient.CalciumCarbonate);
 Fillers.add(Ingredient.HydratedSilica);
-Fillers.add(Ingredient.PEG136PolyvinylAlcohol);
 Fillers.add(Ingredient.SaltCake);
 Fillers.add(Ingredient.Silica);
 Fillers.add(Ingredient.SodiumSulfate);

--- a/src/components/common/types/Ingredient.ts
+++ b/src/components/common/types/Ingredient.ts
@@ -123,6 +123,11 @@ export enum Ingredient {
   C12_16Pareth = 'C12-16 Pareth',
   C12_18FattyAcidsSodiumSalt = 'Sodium Salts of C12-18 Fatty Acids',
   C16_18FattyAcidsSodiumSalt = 'C16-18 fatty acids sodium salt',
+  /**
+   * Calcium Carbonate is an inorganic mineral used in powder laundry detergents primarily as
+   * a bulking/filler agent. It also acts as a mild abrasive that can assist in loosening
+   * surface soils during agitation.
+   */
   CalciumCarbonate = 'Calcium Carbonate',
   /**
    * Calcium Chloride is an inorganic salt used in laundry detergents as a viscosity modifier

--- a/src/components/common/types/Ingredient.ts
+++ b/src/components/common/types/Ingredient.ts
@@ -721,6 +721,13 @@ export enum Ingredient {
    * suds modifier and conditioning agent that reduces excess foam while improving fabric feel.
    */
   PEG12Dimethicone = 'PEG-12 Dimethicone',
+  /**
+   * PEG-136 Polyvinyl Alcohol is a graft copolymer of polyethylene glycol (PEG, ~136 ethylene
+   * oxide units, MW ~6000) onto a polyvinyl alcohol backbone. The PEG modification improves
+   * water solubility and dissolution rate relative to plain PVA, making it suitable for
+   * unit-dose pac film applications — particularly for fast-dissolving outer layers or
+   * multi-compartment pod dividers.
+   */
   PEG136PolyvinylAlcohol = 'PEG-136 Polyvinyl Alcohol',
   /**
    * PEG Terephthalate Polymer is a polyester-based polymer used in laundry detergents

--- a/src/components/common/types/PacFilm.ts
+++ b/src/components/common/types/PacFilm.ts
@@ -13,6 +13,7 @@ import { Ingredient } from './Ingredient';
  */
 const PacFilm: Set<Ingredient> = new Set();
 
+PacFilm.add(Ingredient.PEG136PolyvinylAlcohol);
 PacFilm.add(Ingredient.PolyvinylAlcohol);
 PacFilm.add(Ingredient.PolyvinylAlcoholFilm);
 PacFilm.add(Ingredient.PolyvinylAlcoholPolymer);

--- a/src/components/common/types/ProcessingAids.ts
+++ b/src/components/common/types/ProcessingAids.ts
@@ -4,5 +4,6 @@ const ProcessingAids: Set<Ingredient> = new Set();
 
 ProcessingAids.add(Ingredient.C16_18FattyAcidsSodiumSalt);
 ProcessingAids.add(Ingredient.FattyAcidsC8_18AndC18UnsaturatedSodiumSalts);
+ProcessingAids.add(Ingredient.HydratedSilica);
 
 export { ProcessingAids };


### PR DESCRIPTION
## Summary

- Moves `PEG-136 Polyvinyl Alcohol` from `Fillers` to `PacFilm` — it is a water-soluble graft copolymer used as pac film material, not a bulking agent
- Adds `HydratedSilica` to `ProcessingAids` as a dual-category entry (it is documented as a flow aid/anti-caking agent, which is a manufacturing/processing role)
- Adds JSDoc to `CalciumCarbonate` noting its primary filler role and secondary mild-abrasive function
- Adds JSDoc to `PEG-136 Polyvinyl Alcohol` explaining its PEG-graft structure and pac film application

## Test plan

- [x] `npm run checks` passes (lint, type-check, 244 tests, format)
- [x] Verify `gain-flings-moonlight-breeze` profile — both `PEG136PolyvinylAlcohol` and `PolyvinylAlcoholPolymer` are distinct substances (different PVA grades used in multi-compartment pod film) and should remain as separate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)