### PR TITLE
Add Kirkland Signature UltraClean Free and Clear

### DIFF
--- a/src/components/Detergent/data/profiles/index.ts
+++ b/src/components/Detergent/data/profiles/index.ts
@@ -66,6 +66,7 @@ export { default as GreatValuePremiumCleanOriginalPacs } from './great-value-pre
 export { default as GreatValueUltimateFreshOriginalClean } from './great-value-ultimate-fresh-original-clean';
 export { default as GreatValueUltimateFreshOriginalCleanPacs } from './great-value-ultimate-fresh-original-clean-pacs';
 export { default as GuestsOnEarthLaundryDetergentGreenHinoki } from './guests-on-earth-laundry-detergent-green-hinoki';
+export { default as KirklandSignatureUltraCleanFreeAndClear } from './kirkland-signature-ultraclean-free-and-clear';
 export { default as MethodGingerMangoLaundryDetergent } from './method-ginger-mango-laundry-detergent';
 export { default as MethodLaundryDetergentBeachSage } from './method-laundry-detergent-beach-sage';
 export { default as MethodLaundryDetergentFreeClear } from './method-laundry-detergent-free-clear';

--- a/src/components/Detergent/data/profiles/kirkland-signature-ultraclean-free-and-clear.ts
+++ b/src/components/Detergent/data/profiles/kirkland-signature-ultraclean-free-and-clear.ts
@@ -1,0 +1,38 @@
+import { Ingredient } from '../../../common/types/Ingredient';
+import { DetergentProfile } from '../../types/DetergentProfile';
+import { DetergentType } from '../../types/DetergentType';
+import { DataSource } from '../../types/DataSource';
+
+const ingredients: Ingredient[] = [
+  Ingredient.C12_15AlcoholsEthoxylated,
+  Ingredient.SodiumC10_16Alkylbenzenesulfonate,
+  Ingredient.MEALAS,
+  Ingredient.SodiumLaurethSulfate,
+  Ingredient.PolyethyleneimineAlkoxylated,
+  Ingredient.TetrasodiumIminodisuccinate,
+  Ingredient.Triethanolamine,
+  Ingredient.HydrophobicallyModifiedAcrylateStyreneCopolymer,
+  Ingredient.FattyAcidsC8_18AndC18UnsaturatedSodiumSalts,
+  Ingredient.LinearAlkylbenzeneSulfonicAcid, // also listed as: Alkylbenzene Sulfonic Acid
+  Ingredient.Ethanol,
+  Ingredient.Protease,
+  Ingredient.SodiumCitrate,
+  Ingredient.CalciumChloride,
+  Ingredient.DisodiumDistyrylbiphenylDisulfonate,
+  Ingredient.Amylase,
+  Ingredient.Methylisothiazolinone,
+  Ingredient.Mannanase,
+  Ingredient.Methylchloroisothiazolinone,
+];
+
+const KirklandSignatureUltraCleanFreeAndClear: DetergentProfile = new DetergentProfile(
+  'UltraClean Free and Clear',
+  'Kirkland Signature',
+  DetergentType.Liquid,
+  DataSource.Package,
+  ingredients,
+  new Date('2026-02-01'),
+);
+KirklandSignatureUltraCleanFreeAndClear.countryOfOrigin = 'USA';
+KirklandSignatureUltraCleanFreeAndClear.countriesAvailable = ['AUS', 'USA'];
+export default KirklandSignatureUltraCleanFreeAndClear;

--- a/src/components/common/types/Ingredient.ts
+++ b/src/components/common/types/Ingredient.ts
@@ -551,6 +551,7 @@ export enum Ingredient {
    * Linear Alkylbenzene Sulfonic Acid (LABSA) is an anionic surfactant and the free acid form
    * of linear alkylbenzene sulfonate (LAS), used in laundry detergents as a primary cleaning
    * agent. Distinct from its sodium salt (Sodium C10-16 Alkylbenzenesulfonate).
+   * Synonyms: Alkylbenzene Sulfonic Acid
    */
   LinearAlkylbenzeneSulfonicAcid = 'Linear Alkylbenzene Sulfonic Acid',
   Lipase = 'Lipase',


### PR DESCRIPTION
## Description

Closes #549

Add detergent product: **Kirkland Signature UltraClean Free and Clear**

## Unknowns / Ambiguities

- Water is not printed in the ingredient list on this packaging.
- "Alkylbenzene Sulfonic Acid" (ingredient #10) mapped to `Ingredient.LinearAlkylbenzeneSulfonicAcid`. The label omits the "Linear" qualifier — a common US labeling convention confirmed by pre-reformulation EWG disclosures for this product line. Synonym added to JSDoc.

## Source(s)

- **Primary source:** Package (photo)
- **Date accessed:** 2026-02-01
- **Region:** USA (also available in Australia)