### PR TITLE
Add direct profile linking to DetergentDetailCard

### DIFF
--- a/src/components/Detergent/DetergentDetailCard.css
+++ b/src/components/Detergent/DetergentDetailCard.css
@@ -66,3 +66,18 @@
 .detail-meta-value {
   color: var(--color-text-value);
 }
+
+.detail-copy-link-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  color: var(--color-text-muted);
+  line-height: 1;
+  margin-left: auto;
+}
+
+.detail-copy-link-btn:hover {
+  color: var(--color-text-primary);
+}

--- a/src/components/Detergent/DetergentDetailCard.tsx
+++ b/src/components/Detergent/DetergentDetailCard.tsx
@@ -1,8 +1,10 @@
+import { useState, useCallback } from 'react';
 import { registerLocale, getName } from 'i18n-iso-countries';
 import enLocale from 'i18n-iso-countries/langs/en.json';
 import { Drawer } from '../common/Drawer';
 import { DetergentProfile } from './types/DetergentProfile';
 import { getIngredientCategories } from '../common/types/IngredientCategoryMap';
+import { toDetergentSlug } from './utils/detergentSlug';
 import './DetergentDetailCard.css';
 
 registerLocale(enLocale);
@@ -17,7 +19,18 @@ function formatIngredient(name: string): string {
 }
 
 export function DetergentDetailCard({ detergent, onClose }: DetergentDetailCardProps) {
+  const [copied, setCopied] = useState(false);
   const countryNames = detergent?.countriesAvailable?.map((code) => getName(code, 'en') ?? code).join(', ') ?? '—';
+
+  const handleCopyLink = useCallback(() => {
+    if (!navigator.clipboard || !detergent) return;
+    const url = new URL(window.location.pathname, window.location.origin);
+    url.searchParams.set('d', toDetergentSlug(detergent));
+    void navigator.clipboard.writeText(url.toString()).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [detergent]);
 
   return (
     <Drawer
@@ -25,6 +38,18 @@ export function DetergentDetailCard({ detergent, onClose }: DetergentDetailCardP
       onClose={onClose}
       title={`${detergent?.brand} ${detergent?.name ?? ''}`}
       side="right"
+      headerActions={
+        detergent && (
+          <button
+            className="detail-copy-link-btn"
+            onClick={handleCopyLink}
+            aria-label="Copy link to this product"
+            title="Copy link"
+          >
+            {copied ? '✓' : '⎘'}
+          </button>
+        )
+      }
     >
       {detergent && (
         <>

--- a/src/components/Detergent/Detergents.tsx
+++ b/src/components/Detergent/Detergents.tsx
@@ -17,6 +17,8 @@ import { DetergentType } from './types/DetergentType';
 import { loadDetergents } from './data/detergents-data';
 import { useGridFilterSync } from './hooks/useGridFilterSync';
 import { useGridSortSync } from './hooks/useGridSortSync';
+import { useDetergentUrlSync } from './hooks/useDetergentUrlSync';
+import { toDetergentSlug, findDetergentBySlug } from './utils/detergentSlug';
 import { getDefaultSort } from './utils/gridSortUtils';
 import { Drawer } from '../common/Drawer';
 import { FilterDrawerContent } from './FilterDrawerContent';
@@ -150,8 +152,10 @@ function Detergents() {
   const [selectedDetergent, setSelectedDetergent] = useState<DetergentProfile | null>(null);
   const { filter: urlFilter, updateFilterInUrl, resetFilterInUrl } = useGridFilterSync();
   const { sortModel, updateSortInUrl, resetSortInUrl } = useGridSortSync();
+  const { slug: detergentSlug, setDetergentSlug } = useDetergentUrlSync();
   const gridRef = useRef<AgGridReact<DetergentProfile>>(null);
   const isFirstSortRender = useRef(true);
+  const detergentUrlInitialized = useRef(false);
 
   // Store the initial filter from URL for reset functionality
   const initialFilterRef = useRef<CompositeFilterDescriptor | null>(null);
@@ -182,6 +186,27 @@ function Detergents() {
       }
     }
   }, [urlFilter]);
+
+  // Restore selected detergent from URL on initial data load
+  useEffect(() => {
+    if (detergents.size === 0 || detergentUrlInitialized.current) return;
+    detergentUrlInitialized.current = true;
+    if (!detergentSlug) return;
+    const found = findDetergentBySlug(detergentSlug, detergents);
+    if (found) setSelectedDetergent(found);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detergents]);
+
+  // Sync URL slug → selectedDetergent for back/forward navigation
+  useEffect(() => {
+    if (!detergentUrlInitialized.current) return;
+    if (!detergentSlug) {
+      setSelectedDetergent(null);
+      return;
+    }
+    const found = findDetergentBySlug(detergentSlug, detergents);
+    setSelectedDetergent(found);
+  }, [detergentSlug, detergents]);
 
   // Handle filter changes from FilterDrawer and update URL
   const handleFilterChange = useCallback(
@@ -218,9 +243,13 @@ function Detergents() {
     updateSortInUrl(sorted);
   }, [updateSortInUrl]);
 
-  const handleNameClick = useCallback((detergent: DetergentProfile) => {
-    setSelectedDetergent(detergent);
-  }, []);
+  const handleNameClick = useCallback(
+    (detergent: DetergentProfile) => {
+      setSelectedDetergent(detergent);
+      setDetergentSlug(toDetergentSlug(detergent));
+    },
+    [setDetergentSlug],
+  );
 
   const resetFilter = useCallback(() => {
     // Reset to the initial filter from URL — use immediate variant to avoid debounce race with sort reset
@@ -267,7 +296,13 @@ function Detergents() {
           <FilterBar onClick={() => setIsDrawerOpen(true)} isVisible={!isDrawerOpen} />
 
           {/* Detail Card */}
-          <DetergentDetailCard detergent={selectedDetergent} onClose={() => setSelectedDetergent(null)} />
+          <DetergentDetailCard
+            detergent={selectedDetergent}
+            onClose={() => {
+              setSelectedDetergent(null);
+              setDetergentSlug(null);
+            }}
+          />
 
           {/* Filter Drawer */}
           <Drawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)} title="Filter Detergents">

--- a/src/components/Detergent/__tests__/DetergentDetailCard.test.tsx
+++ b/src/components/Detergent/__tests__/DetergentDetailCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DetergentDetailCard } from '../DetergentDetailCard';
 import { DetergentProfile } from '../types/DetergentProfile';
@@ -132,6 +132,48 @@ describe('DetergentDetailCard', () => {
 
       const countriesValue = screen.getByText('Countries').nextElementSibling;
       expect(countriesValue).toHaveTextContent('—');
+    });
+  });
+
+  describe('copy link button', () => {
+    it('renders the copy link button when a detergent is provided', () => {
+      const detergent = makeDetergent();
+      render(<DetergentDetailCard detergent={detergent} onClose={() => {}} />);
+
+      expect(screen.getByRole('button', { name: 'Copy link to this product' })).toBeInTheDocument();
+    });
+
+    it('does not render the copy link button when detergent is null', () => {
+      render(<DetergentDetailCard detergent={null} onClose={() => {}} />);
+
+      expect(screen.queryByRole('button', { name: 'Copy link to this product' })).not.toBeInTheDocument();
+    });
+
+    it('copies window.location.href to clipboard when clicked', async () => {
+      // userEvent.setup() automatically stubs navigator.clipboard
+      const user = userEvent.setup();
+      const detergent = makeDetergent();
+      render(<DetergentDetailCard detergent={detergent} onClose={() => {}} />);
+
+      const copyBtn = screen.getByRole('button', { name: 'Copy link to this product' });
+      await user.click(copyBtn);
+
+      const expectedUrl = new URL(window.location.pathname, window.location.origin);
+      expectedUrl.searchParams.set('d', 'tide-clean-breeze');
+      expect(await navigator.clipboard.readText()).toBe(expectedUrl.toString());
+    });
+
+    it('shows the copied state briefly after clicking', async () => {
+      const user = userEvent.setup();
+      const detergent = makeDetergent();
+      render(<DetergentDetailCard detergent={detergent} onClose={() => {}} />);
+
+      const copyBtn = screen.getByRole('button', { name: 'Copy link to this product' });
+      expect(copyBtn).toHaveTextContent('⎘');
+
+      await user.click(copyBtn);
+
+      await waitFor(() => expect(copyBtn).toHaveTextContent('✓'));
     });
   });
 

--- a/src/components/Detergent/hooks/useDetergentUrlSync.ts
+++ b/src/components/Detergent/hooks/useDetergentUrlSync.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const DETERGENT_PARAM = 'd';
+
+export function useDetergentUrlSync() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const slug = searchParams.get(DETERGENT_PARAM);
+
+  const setDetergentSlug = useCallback(
+    (newSlug: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev.toString());
+          if (newSlug) {
+            params.set(DETERGENT_PARAM, newSlug);
+          } else {
+            params.delete(DETERGENT_PARAM);
+          }
+          return params;
+        },
+        { replace: false },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return { slug, setDetergentSlug };
+}

--- a/src/components/Detergent/utils/detergentSlug.ts
+++ b/src/components/Detergent/utils/detergentSlug.ts
@@ -1,0 +1,17 @@
+import { DetergentProfile } from '../types/DetergentProfile';
+
+export function toDetergentSlug(detergent: DetergentProfile): string {
+  return `${detergent.brand} ${detergent.name}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function findDetergentBySlug(slug: string, detergents: Map<string, DetergentProfile>): DetergentProfile | null {
+  for (const detergent of detergents.values()) {
+    if (toDetergentSlug(detergent) === slug) {
+      return detergent;
+    }
+  }
+  return null;
+}

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -7,12 +7,13 @@ interface DrawerProps {
   children: ReactNode;
   title?: string;
   side?: 'left' | 'right';
+  headerActions?: ReactNode;
 }
 
 /**
  * A simple drawer component that slides in from the left side of the screen
  */
-export function Drawer({ isOpen, onClose, children, title, side = 'left' }: DrawerProps) {
+export function Drawer({ isOpen, onClose, children, title, side = 'left', headerActions }: DrawerProps) {
   const titleId = useId();
   // Handle escape key to close drawer
   useEffect(() => {
@@ -48,6 +49,7 @@ export function Drawer({ isOpen, onClose, children, title, side = 'left' }: Draw
       >
         <div className="drawer-header">
           {title && <h2 id={titleId}>{title}</h2>}
+          {headerActions}
           <button className="drawer-close-btn" onClick={onClose} aria-label="Close drawer">
             ✕
           </button>


### PR DESCRIPTION
Opening a detergent drawer now writes ?d=<slug> to the URL so the view is shareable and bookmarkable. Following a link with ?d= restores the drawer on load; browser Back/Forward open and close it naturally.

A copy-link button (⎘/✓) in the drawer header copies a clean URL containing only the ?d= param, leaving active filters out of the link.