### PR TITLE
Bump github/codeql-action init and analyze to 4.36.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: 'friday'
     cooldown:
       default-days: 7
+    groups:
+      codeql-action:
+        patterns:
+          - 'github/codeql-action/*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # github/codeql-action/init@v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # github/codeql-action/init@v4.36.3
         with:
           languages: actions
           build-mode: none

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -37,6 +37,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # github/codeql-action/analyze@v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # github/codeql-action/analyze@v4.36.3
         with:
           category: '/language:actions'

--- a/.github/workflows/codeql-jsts.yml
+++ b/.github/workflows/codeql-jsts.yml
@@ -41,6 +41,6 @@ jobs:
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # github/codeql-action/analyze@v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # github/codeql-action/analyze@v4.36.3
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/codeql-jsts.yml
+++ b/.github/workflows/codeql-jsts.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # github/codeql-action/init@v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # github/codeql-action/init@v4.36.3
         with:
           languages: javascript-typescript
           build-mode: none


### PR DESCRIPTION
Combines the two dependabot PRs bumping `github/codeql-action` from 4.36.2 to 4.36.3, since `init` and `analyze` must move together to stay compatible.

Also updates `.github/dependabot.yml` to group future `github/codeql-action/*` updates into a single PR automatically, so this split doesn't happen again.

Closes #595
Closes #596