### PR TITLE
Add merge-dependabot skill and split Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; M=.claude/.checks-ok; if [ ! -f \"$M\" ] || find src .claude package.json tsconfig.json *.md -newer \"$M\" -type f 2>/dev/null | grep -q .; then npm run checks || exit 2; touch \"$M\"; fi",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; M=.claude/.checks-ok; H=$( { git diff HEAD; git ls-files -o --exclude-standard -z | xargs -0 -r sha1sum; } 2>/dev/null | git hash-object --stdin ); [ -f \"$M\" ] && [ \"$(cat \"$M\")\" = \"$H\" ] && exit 0; npm run checks || exit 2; printf %s \"$H\" > \"$M\"",
             "timeout": 300,
             "statusMessage": "Running checks..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; M=.claude/.checks-ok; H=$( { git diff HEAD; git ls-files -o --exclude-standard -z | xargs -0 -r sha1sum; } 2>/dev/null | git hash-object --stdin ); [ -f \"$M\" ] && [ \"$(cat \"$M\")\" = \"$H\" ] && exit 0; npm run checks || exit 2; printf %s \"$H\" > \"$M\"",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; M=.claude/.checks-ok; H=$(git status --porcelain -uall -z | cut -z -c4- | xargs -0 -r stat -c '%n|%s|%y' 2>/dev/null | git hash-object --stdin); [ -f \"$M\" ] && [ \"$(cat \"$M\")\" = \"$H\" ] && exit 0; npm run checks || exit 2; printf %s \"$H\" > \"$M\"",
             "timeout": 300,
             "statusMessage": "Running checks..."
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cat oxlint.config.*)",
+      "Bash(npx oxfmt:*)",
+      "Bash(npx jest:*)",
+      "PowerShell(npm run:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)"
+    ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" || exit 0; M=.claude/.checks-ok; if [ ! -f \"$M\" ] || find src .claude package.json tsconfig.json *.md -newer \"$M\" -type f 2>/dev/null | grep -q .; then npm run checks || exit 2; touch \"$M\"; fi",
+            "timeout": 300,
+            "statusMessage": "Running checks..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/merge-dependabot/SKILL.md
+++ b/.claude/skills/merge-dependabot/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: merge-dependabot
+description: This skill should be used when the user asks to "merge dependabot PRs", "clear the dependabot queue", "handle dependency updates", "approve dependabot", or runs /merge-dependabot. Approves Dependabot PRs whose required checks are green so the existing auto-merge workflow completes them, triggers @dependabot rebase on stale ones, and reports PRs needing manual intervention.
+allowed-tools: Bash, Agent, TodoWrite, Read
+---
+
+# Merge Dependabot PRs
+
+Drain the open Dependabot pull request queue by approving PRs whose required checks
+are green, letting `.github/workflows/dependabot-auto-merge.yml` complete the merge.
+
+The only blocker on a healthy Dependabot PR here is `REVIEW_REQUIRED` — the `main`
+ruleset demands one approving review and no bot can supply it. Auto-merge is already
+enabled by the workflow, so **an approval is the action; a merge is not.**
+
+Read `references/repo-context.md` before the first decision of a run.
+
+## Constraints that dictate the algorithm
+
+- `dismiss_stale_reviews_on_push` + `require_last_push_approval` mean a rebase **erases**
+  a prior approval. The order is forced: **update → checks green → approve.** Never
+  approve a PR that is `BEHIND`.
+- `required_status_checks` is **strict** — every merge makes the remaining PRs stale.
+  Process PRs **strictly one at a time**, never in parallel.
+
+Run inventory, decisions, approvals, and waiting inline in this session. Delegate to a
+subagent for exactly one case: a red required check (step 5).
+
+## Workflow
+
+### 1. Inventory
+
+```bash
+gh pr list --author "app/dependabot" --state open --limit 50 \
+  --json number,title,createdAt,mergeStateStatus,mergeable,reviewDecision,autoMergeRequest,statusCheckRollup
+```
+
+Sort **newest → oldest**; newer grouped PRs frequently supersede older ones. Seed
+`TodoWrite` with one item per PR.
+
+If the user passed `--dry-run`, print the decision table (PR, title, state, intended
+action) and stop. Perform zero writes.
+
+### 2. Process one PR at a time
+
+Substitute the PR number for `<N>` throughout. Re-fetch state per PR rather than
+trusting the inventory snapshot — an earlier merge in this run may have invalidated it:
+
+```bash
+gh pr view <N> --json number,title,state,mergeStateStatus,mergeable,reviewDecision,autoMergeRequest,statusCheckRollup,headRefOid
+```
+
+Required checks are exactly `lint-and-build` and `CodeQL`; `NEUTRAL` counts as passing
+(see `references/repo-context.md`):
+
+```bash
+gh pr view <N> --json statusCheckRollup \
+  -q '.statusCheckRollup[] | select(.name=="lint-and-build" or .name=="CodeQL") | "\(.name) \(.conclusion // .status)"'
+```
+
+Unresolved review threads are **not** a `gh pr view` field — they need GraphQL:
+
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{isResolved}}}}}' \
+  -F o='{owner}' -F r='{repo}' -F n=<N> \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length'
+```
+
+Decide. Evaluate rows top-down and take the first match:
+
+| Observed state                                          | Action                                                         |
+| ------------------------------------------------------- | -------------------------------------------------------------- |
+| `state` is `MERGED` / `CLOSED`                          | Drop — superseded by a newer group PR                          |
+| `mergeStateStatus` **or** `mergeable` is `UNKNOWN`      | **Unsettled** — settle first, below, then re-decide            |
+| `reviewDecision: APPROVED`, auto-merge on, checks green | Nothing — re-entrancy guard                                    |
+| `autoMergeRequest` is null                              | Record `BLOCKED:no-auto-merge` (workflow path filter)          |
+| unresolved threads > 0                                  | Record `BLOCKED:unresolved-threads` — a human must resolve     |
+| `mergeStateStatus: BEHIND`                              | Arm the waiter (step 3)                                        |
+| `mergeable: CONFLICTING` / `DIRTY`                      | Post `@dependabot recreate` once, then arm the waiter          |
+| required checks `PENDING`                               | Wait for checks, below → else `BLOCKED:checks-pending`         |
+| any required check failed                               | Delegate triage (step 5); record `BLOCKED:check-failed:<name>` |
+| `BLOCKED` + `MERGEABLE` + checks green                  | Approve, below                                                 |
+
+#### Settle an `UNKNOWN` state before classifying
+
+GitHub recomputes mergeability after every merge to `main`, and reports `UNKNOWN` on one
+or both fields while it does — observed lasting over a minute on this repo. **Never
+approve an unsettled PR.** `BEHIND` frequently hides under `UNKNOWN`, and approving a
+`BEHIND` PR gets the approval silently discarded by `require_last_push_approval`.
+
+```bash
+PR=<N>; DEADLINE=$((SECONDS+180))
+while [ $SECONDS -lt $DEADLINE ]; do
+  read -r MSS MRG < <(gh pr view "$PR" --json mergeStateStatus,mergeable \
+    -q '"\(.mergeStateStatus) \(.mergeable)"')
+  [ "$MSS" != "UNKNOWN" ] && [ "$MRG" != "UNKNOWN" ] && { echo "SETTLED $PR $MSS $MRG"; exit 0; }
+  sleep 20
+done
+echo "UNSETTLED $PR — still UNKNOWN after 180s"
+```
+
+On `SETTLED`, re-run the decision table with the new values. On `UNSETTLED`, record
+`BLOCKED:mergeable-unknown`.
+
+#### Wait for pending required checks
+
+```bash
+PR=<N>; DEADLINE=$((SECONDS+600))
+while [ $SECONDS -lt $DEADLINE ]; do
+  PENDING=$(gh pr view "$PR" --json statusCheckRollup \
+    -q '[.statusCheckRollup[] | select(.name=="lint-and-build" or .name=="CodeQL")
+         | select((.conclusion // "") == "")] | length')
+  [ "$PENDING" = "0" ] && { echo "CHECKS_DONE $PR"; exit 0; }
+  sleep 30
+done
+echo "CHECKS_PENDING $PR — still running after 600s"
+```
+
+#### Approve
+
+```bash
+gh pr review <N> --approve --body "Required checks green; approving to release auto-merge."
+gh pr view <N> --json reviewDecision -q .reviewDecision    # expect APPROVED
+```
+
+Confirm the merge, bounded:
+
+```bash
+DEADLINE=$((SECONDS+300))
+while [ $SECONDS -lt $DEADLINE ]; do
+  STATE=$(gh pr view <N> --json state -q .state)
+  [ "$STATE" != "OPEN" ] && { echo "MERGE_STATE=$STATE"; break; }
+  sleep 20
+done
+```
+
+On `MERGED`, re-inventory and advance to the next PR. The rest of the queue will have
+flipped to `BEHIND`; leave it alone. Act on **only that one PR** — never arm a waiter for,
+comment on, or rebase the others. Each subsequent merge re-stales everything behind it, so
+rebasing the queue in bulk costs a redundant `lint-and-build` + `CodeQL` run per PR per
+merge (~21 runs to drain six PRs, against six done sequentially) and ends in the same place.
+
+### 3. Wait with an escalating nudge
+
+**Exactly one waiter runs at a time**, for the PR currently being processed. Other
+`BEHIND` PRs are not monitored and not nudged — their turn comes after this one merges.
+
+Dependabot often rebases stale PRs unprompted, but not reliably. Never assume it picked
+up the work: `mergeStateStatus` reads `BEHIND` for both an idle PR and one mid-rebase,
+so watch two independent signals instead.
+
+| Signal                                         | Meaning                                        |
+| ---------------------------------------------- | ---------------------------------------------- |
+| `headRefOid` changed from baseline             | Rebase **landed** — terminal success           |
+| Body contains `Dependabot is rebasing this PR` | **Acknowledged**, still working — keep waiting |
+| Neither, past threshold                        | **Stalled** — needs a nudge                    |
+
+Run the waiter with `Bash(run_in_background: true)` so it emits one notification and exits:
+
+```bash
+PR=<N>
+BASE_OID=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+DEADLINE=$((SECONDS+240)); ACKED=0
+while [ $SECONDS -lt $DEADLINE ]; do
+  sleep 30
+  OID=$(gh pr view "$PR" --json headRefOid -q .headRefOid) || continue
+  [ -n "$OID" ] && [ "$OID" != "$BASE_OID" ] && { echo "REBASED $PR"; exit 0; }
+  # Test positively: GitHub returns UNKNOWN while recomputing mergeability.
+  MSS=$(gh pr view "$PR" --json mergeStateStatus -q .mergeStateStatus)
+  case "$MSS" in
+    BLOCKED|CLEAN|HAS_HOOKS) echo "READY $PR"; exit 0 ;;
+  esac
+  if [ $ACKED -eq 0 ] && gh pr view "$PR" --json body -q .body | grep -q "Dependabot is rebasing this PR"; then
+    ACKED=1; DEADLINE=$((SECONDS+600)); echo "ACK $PR — dependabot working"
+  fi
+done
+echo "NUDGE $PR — no rebase activity"
+```
+
+Escalation:
+
+- **0–4 min** — poll every 30s for a `headRefOid` change or the rebasing marker.
+- **`NUDGE` at 4 min** — post `@dependabot rebase` (subject to the anti-spam check in
+  `references/repo-context.md`), then re-arm the waiter with a 10-minute window.
+- **Second timeout** — record `BLOCKED:no-rebase-response`. Do not nudge a third time.
+
+Every exit path prints a line, so a `/loop` run never hangs on a job that never started.
+
+### 4. Terminate and report
+
+Stop when the queue is empty or only blocked items remain. Emit a final table:
+PR, title, outcome, reason.
+
+### 5. Triage a failed check (subagent)
+
+Only when a required check is red. Dispatch with
+`Agent(subagent_type: "general-purpose", model: "sonnet", run_in_background: false)`
+using the prompt in `references/triage-prompt.md`. It returns a short summary; the CI
+log itself never enters this session.
+
+## Re-entrancy
+
+Safe under `/loop 30m /merge-dependabot`. A PR already `APPROVED` with auto-merge on and
+green checks is skipped — no duplicate review. Rebase comments are capped at two per head
+commit, so repeated runs never accumulate comments on a dead PR.
+
+## Notes
+
+- **No code changes.** Never edit files, never `git push`, never hand-edit
+  `package-lock.json`. A PR needing a code fix is reported, not fixed.
+- **Never `gh pr merge --admin`.** Admin rights exist and the ruleset has a bypass, but
+  using it skips required checks. Approve and let the workflow merge.
+- **Never `gh pr close`.** Let Dependabot supersede its own PRs.
+- Only `@dependabot rebase` and `recreate` still work. Never emit `merge`, `cancel merge`,
+  `squash and merge`, `close`, or `reopen`.
+
+## Additional Resources
+
+- **`references/repo-context.md`** — ruleset settings, check-name gotchas, the auto-merge
+  path filter, anti-spam rules.
+- **`references/triage-prompt.md`** — verbatim prompt for the failed-check subagent.

--- a/.claude/skills/merge-dependabot/SKILL.md
+++ b/.claude/skills/merge-dependabot/SKILL.md
@@ -76,7 +76,7 @@ Decide. Evaluate rows top-down and take the first match:
 | `autoMergeRequest` is null                              | Record `BLOCKED:no-auto-merge` (workflow path filter)          |
 | unresolved threads > 0                                  | Record `BLOCKED:unresolved-threads` — a human must resolve     |
 | `mergeStateStatus: BEHIND`                              | Arm the waiter (step 3)                                        |
-| `mergeable: CONFLICTING` / `DIRTY`                      | Post `@dependabot recreate` once, then arm the waiter          |
+| `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY`   | Post `@dependabot recreate` once, then arm the waiter          |
 | required checks `PENDING`                               | Wait for checks, below → else `BLOCKED:checks-pending`         |
 | any required check failed                               | Delegate triage (step 5); record `BLOCKED:check-failed:<name>` |
 | `BLOCKED` + `MERGEABLE` + checks green                  | Approve, below                                                 |

--- a/.claude/skills/merge-dependabot/references/repo-context.md
+++ b/.claude/skills/merge-dependabot/references/repo-context.md
@@ -1,0 +1,85 @@
+# Repo context for merge-dependabot
+
+Facts gathered from the live repo. Re-verify with
+`gh api repos/{owner}/{repo}/rulesets/12323881` if behavior stops matching this document.
+
+## The `main` ruleset (id `12323881`)
+
+| Rule / setting                                   | Value              | Consequence                                                        |
+| ------------------------------------------------ | ------------------ | ------------------------------------------------------------------ |
+| `required_approving_review_count`                | `1`                | The sole blocker on healthy Dependabot PRs. No bot can satisfy it. |
+| `dismiss_stale_reviews_on_push`                  | `true`             | A rebase **erases** a prior approval.                              |
+| `require_last_push_approval`                     | `true`             | The approval must come after the final push.                       |
+| `required_review_thread_resolution`              | `true`             | An unresolved thread blocks the merge **after** a green approval.  |
+| `required_status_checks`                         | strict             | Branch must be up to date; every merge stales the rest.            |
+| `code_quality`                                   | `severity: errors` | Can block independently of the two named checks.                   |
+| `allowed_merge_methods`                          | `["squash"]`       | Matches the workflow's `--squash`.                                 |
+| `required_linear_history`, `required_signatures` | `true`             | Dependabot's own commits satisfy both.                             |
+| `require_code_owner_review`                      | `true`             | Currently a **no-op** — no CODEOWNERS file exists.                 |
+
+`required_review_thread_resolution` produces the confusing state "approved, auto-merge on,
+never merges." Run the GraphQL `reviewThreads` query in SKILL.md step 2 before assuming a
+stall is Dependabot's fault — the field is not available on `gh pr view`.
+
+## Required checks
+
+- `lint-and-build`
+- `CodeQL`
+
+**Gotcha:** `CodeQL` reports `conclusion: NEUTRAL`, and **NEUTRAL counts as passing.**
+Treating it as a failure would make the skill refuse every PR. Only `FAILURE`,
+`TIMED_OUT`, `CANCELLED`, and `ACTION_REQUIRED` are failures.
+
+Non-required checks may be red without blocking the merge. The two above are the entire
+`required_status_checks` list — do not assume every entry in `statusCheckRollup` gates.
+
+## Auto-merge and its path filter
+
+`.github/workflows/dependabot-auto-merge.yml` runs `gh pr merge --auto --squash "$PR_URL"`,
+guarded by `if: github.actor == 'dependabot[bot]'` plus a sender-type verification step.
+When it runs, `autoMergeRequest` is set and the merge fires the moment `reviewDecision`
+becomes `APPROVED` and checks are green. **Never merge manually.**
+
+**But it is path-filtered** to `**/package.json`, `**/package-lock.json`, and `.github/**`.
+A Dependabot PR touching nothing in those paths never gets auto-merge enabled, so approving
+it accomplishes nothing and the skill would wait on a merge that cannot happen. **Always
+check `autoMergeRequest` for null** before approving; report `BLOCKED:no-auto-merge` if it
+is. Every npm and Actions PR qualifies; a new ecosystem (Docker, submodules) would not.
+
+## Dependabot comment commands
+
+Supported: `@dependabot rebase`, `@dependabot recreate`.
+
+**Removed 2026-01-27** — never emit these, they are silently ignored:
+`merge`, `cancel merge`, `squash and merge`, `close`, `reopen`.
+
+### Acknowledgement protocol
+
+Dependabot acknowledges a command with a 👍 reaction and by rewriting the PR body to
+contain `Dependabot is rebasing this PR`, then rewrites it again when finished.
+Acknowledgement can take several minutes when it is busy. Treat the marker as
+**"working"**, not "finished" — only a changed `headRefOid` means the rebase landed.
+
+### Anti-spam (critical for `/loop`)
+
+Before posting `@dependabot rebase`:
+
+```bash
+gh pr view <N> --json comments,headRefOid
+```
+
+Skip the comment if a rebase comment already exists that is **newer than the current head
+commit**. Cap at **two nudges per head commit** — a new `headRefOid` resets the count, so
+a PR that legitimately rebases twice still gets help, while a dead one stops accumulating
+comments across `/loop` iterations.
+
+### 30-day staleness
+
+Dependabot stops auto-rebasing PRs untouched for 30 days. Flag those for a manual
+`@dependabot recreate` rather than waiting on the normal rebase path.
+
+## Cadence
+
+Dependabot opens roughly five grouped PRs every Friday. Newer grouped PRs frequently
+supersede older ones, which is why the queue is processed newest → oldest: an older PR
+often closes itself once a newer one merges.

--- a/.claude/skills/merge-dependabot/references/triage-prompt.md
+++ b/.claude/skills/merge-dependabot/references/triage-prompt.md
@@ -1,0 +1,67 @@
+# Failed-check triage prompt
+
+Dispatch **only** when a required check (`lint-and-build` or `CodeQL`) is red on a
+Dependabot PR. Everything else in this skill runs inline in the orchestrator.
+
+`gh run view --log-failed` emits hundreds of lines of CI output that would otherwise
+accumulate across the queue and crowd out the state needed for the final report.
+Delegating turns it into five lines. Use `model: "sonnet"` — the agent only reads and
+summarizes, taking no irreversible action.
+
+## Dispatch
+
+`Agent(subagent_type: "general-purpose", model: "sonnet", run_in_background: false)`
+
+Substitute `<N>` (PR number) and `<CHECK>` (`lint-and-build` or `CodeQL`), then send the
+template below verbatim.
+
+## Prompt template
+
+````
+Required check `<CHECK>` failed on Dependabot PR #<N>. Diagnose why and report back.
+Read only — make no changes of any kind.
+
+Locate the failing run:
+
+```bash
+gh pr checks <N>
+```
+
+Pull the failing log:
+
+```bash
+gh run view <RUN_ID> --log-failed | tail -60
+```
+
+If that is empty or unhelpful, try the specific job:
+
+```bash
+gh run view <RUN_ID> --json jobs -q '.jobs[] | select(.conclusion=="failure") | .databaseId'
+gh run view --job <JOB_ID> --log | tail -60
+```
+
+Useful context: this PR is a dependency bump. The most common causes are a peer-dependency
+conflict, a type error from a bumped `@types/*` package, a lint rule changed by a new
+oxlint version, or a snapshot test broken by a library update. Local checks run via
+`npm run checks` (lint + type-check + test + format).
+
+Hard rules:
+- Read only. Never edit files, never `git push`, never run `npm install`, never touch
+  `package-lock.json`.
+- Never approve, merge, close, or comment on the PR.
+- Do not attempt a fix. Diagnosis only.
+
+Report in exactly this shape — at most 5 lines, no log dumps:
+
+CHECK: <check name>
+CAUSE: <one sentence — the actual failure, not the symptom>
+EVIDENCE: <the single most relevant log line, trimmed>
+FIXABLE: <yes-trivial | yes-nontrivial | no-upstream>
+NEXT: <one sentence — what a human should do>
+````
+
+## Using the result
+
+Record the returned block against the PR as `BLOCKED:check-failed:<name>` and move on to
+the next PR. Do not act on `NEXT` — this skill never changes code. Surface it verbatim in
+the final report so the user can decide.

--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,5 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-.claude/settings.json
+.claude/settings.local.json
+.claude/.checks-ok

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,4 +47,5 @@ Read and follow these — do not duplicate content from them:
 - Use `Closes #<issue_number>` in the PR body to auto-link the issue.
 - Run `npm run checks` before opening a PR and fix all failures.
 - Do not open ready-for-review PRs, merge PRs, or push to `main` directly.
+  - Exception: `/merge-dependabot` may approve Dependabot-authored PRs, letting the existing auto-merge workflow complete them. It must never use `--admin`, never close PRs, and never modify code.
 - SmartLabel pages (`smartlabel.pg.com`) are JavaScript-rendered and inaccessible via fetch. Fall back to the ingredient list in the issue.


### PR DESCRIPTION
Approves Dependabot PRs whose required checks are green so the existing auto-merge workflow completes them, nudges stale ones, and reports PRs needing manual intervention.

The queue blocker is REVIEW_REQUIRED from the main ruleset, not a rebase -- auto-merge is already enabled by dependabot-auto-merge.yml, so an approval is the action and a merge is never issued directly.

Encodes constraints verified against the live ruleset:
- dismiss_stale_reviews_on_push + require_last_push_approval force the order update -> checks green -> approve
- strict required_status_checks forces strictly sequential processing; bulk-rebasing the queue costs quadratic CI for the same end state
- CodeQL reports NEUTRAL, which counts as passing
- required_review_thread_resolution needs a GraphQL query; reviewThreads is not a gh pr view field
- the auto-merge workflow is path-filtered, so autoMergeRequest can be null
- GitHub reports UNKNOWN mergeability for ~30s after each merge, so an unsettled PR is re-polled rather than classified or approved

Work is done inline; a Sonnet subagent is delegated only for triaging a red required check, keeping large CI logs out of the main context.

Also splits .claude/settings.json, which was gitignored in full, into a shared project file and a gitignored settings.local.json for machine-specific paths and write-capable gh grants. The checks hook moves from PostToolUse to Stop so it runs once per turn instead of once per edit, guarded by a marker file and blocking (exit 2) on failure.

Validated end to end on #616 and #615, both merged.