### PR TITLE
Pin packageManager so Dependabot's npm resolves correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node": ">=24.0.0",
     "npm": ">=12.0.1"
   },
+  "packageManager": "npm@12.0.1",
   "allowScripts": {
     "@swc/core": false,
     "unrs-resolver": false


### PR DESCRIPTION
Dependabot's hosted updater picks its npm version via corepack, and falls back to a hardcoded guess of npm 11 when package.json has no packageManager field. That guess violates our engine-strict >=12.0.1 requirement, so every dependency update that needs `npm install` fails with EBADENGINE. Pinning packageManager to npm@12.0.1 lets corepack (and Dependabot) resolve the version it's actually supposed to use.